### PR TITLE
Prevent root shell access from c3270

### DIFF
--- a/tn3270-web-node/run.sh
+++ b/tn3270-web-node/run.sh
@@ -8,5 +8,5 @@ fi
 
 while :
 do
-	shellinaboxd -s :root:root:HOME:"c3270 $TARGET_HOST" -v --css /shellinabox/shellinabox/white-on-black.css
+	shellinaboxd -s :root:root:HOME:"c3270 -secure $TARGET_HOST" -v --css /shellinabox/shellinabox/white-on-black.css
 done


### PR DESCRIPTION
A quick patch to prevent some accessing the root shell via the c3270> prompt.  Passing "-secure" to c3270 prevents access to the c3270> prompt which also restricts access to the tn3270 host:port designated in the run.sh script. 